### PR TITLE
differentiate between published and updated in atom feeds

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -56,7 +56,8 @@ func (this *Feed) readAtom(doc *xmlx.Document) (err error) {
 			i = new(Item)
 			i.Title = item.S(ns, "title")
 			i.Id = item.S(ns, "id")
-			i.PubDate = item.S(ns, "updated")
+			i.PubDate = item.S(ns, "published")
+			i.Updated = item.S(ns, "updated")
 			i.Description = item.S(ns, "summary")
 
 			links := item.SelectNodes(ns, "link")

--- a/item.go
+++ b/item.go
@@ -24,6 +24,7 @@ type Item struct {
 	Generator    *Generator
 	Contributors []string
 	Content      *Content
+	Updated      string
 
 	Extensions map[string]map[string][]Extension
 }


### PR DESCRIPTION
As the title suggests this change introduces a field "updated" in atom feeds.
I don't know if you're interested in this but i need the original pubdate for my current project