### PR TITLE
Fetch more feed images

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -102,6 +102,9 @@ func (this *Feed) readRss2(doc *xmlx.Document) (err error) {
 		if n = node.SelectNode(ns, "image"); n != nil {
 			ch.Image.Title = n.S(ns, "title")
 			ch.Image.Url = n.S(ns, "url")
+			if ch.Image.Url == "" {
+				ch.Image.Url = n.As(ns, "href")
+			}
 			ch.Image.Link = n.S(ns, "link")
 			ch.Image.Width = n.I(ns, "width")
 			ch.Image.Height = n.I(ns, "height")


### PR DESCRIPTION
Hi,
I use your project to develop a very simple podcast fetcher (work in progress for now) : https://github.com/jcnoir/goblackpodder
Your work helps me a lot !
I got an issue with some podcast feeds. Images were not parsed.
Here is an example of one of those feeds : http://feeds.feedburner.com/PuppetLabsPodcast
This image is not parsed correctly : 
```html
<itunes:image href="http://puppetlabs.com/sites/default/files/puppet-labs-podcast-icon.png" />
```
I made a quick fix in this pull request.
Maybe it could be useful to other users ?
Thanks for your work !