### PR TITLE
Add newline to error message

### DIFF
--- a/testdata/example.go
+++ b/testdata/example.go
@@ -37,7 +37,7 @@ func PollFeed(uri string, timeout int, cr xmlx.CharsetFunc) {
 
 	for {
 		if err := feed.Fetch(uri, cr); err != nil {
-			fmt.Fprintf(os.Stderr, "[e] %s: %s", uri, err)
+			fmt.Fprintf(os.Stderr, "[e] %s: %s\n", uri, err)
 			return
 		}
 


### PR DESCRIPTION
Minor change.  I noticed because I get an error message from this program:

tau:~/dev/go-pkg-rss virtualsue$ go run testdata/example.go
15 new item(s) in http://blog.case.edu/news/feed.atom
1 new channel(s) in http://blog.case.edu/news/feed.atom
[e] https://status.rackspace.com/index/rss: XML syntax error on line 155: invalid UTF-8
