### PR TITLE
Allow setting a custom user agent.

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -104,6 +104,9 @@ type Feed struct {
 	// On our next fetch *ONLY* (this will get reset to false afterwards),
 	// ignore all cache settings and update frequency hints, and always fetch.
 	ignoreCacheOnce bool
+
+	// Custom user agent
+	userAgent string
 }
 
 // New is a helper function to stay semi-compatible with
@@ -170,6 +173,10 @@ func (this *Feed) FetchClient(uri string, client *http.Client, charset xmlx.Char
 	this.lastupdate = time.Now().UTC()
 	this.Url = uri
 	doc := xmlx.New()
+
+	if len(this.userAgent) > 1 {
+		doc.SetUserAgent(this.userAgent)
+	}
 
 	if err = doc.LoadUriClient(uri, client, charset); err != nil {
 		return
@@ -357,4 +364,8 @@ func (this *Feed) GetVersionInfo(doc *xmlx.Document) (ftype string, fversion [2]
 	ftype = "unknown"
 	fversion = [2]int{0, 0}
 	return
+}
+
+func (this *Feed) SetUserAgent(s string) {
+	this.userAgent = s
 }


### PR DESCRIPTION
So this is the second step in patching in custom user agent strings, for this package. First step that this PR is depending on is [here](https://github.com/jteeuwen/go-pkg-xmlx/pull/24) (along with why I want/need this functionality). Please do not merge unless that PR has been accepted.

Got the tests running locally but it fails with:
~~~
--- FAIL: Test_ParseLayout5 (0.00s)
	timeparser_test.go:92: expected 2013-07-22 14:55:01 -0500 EST but was 2013-07-22 14:55:01 +0000 EST
~~~
which is unrelated to this PR (because I'm in a different timezone, w0t).
