### PR TITLE
jsonize big int64 in Enclosure as string

### DIFF
--- a/enclosure.go
+++ b/enclosure.go
@@ -2,6 +2,6 @@ package feeder
 
 type Enclosure struct {
 	Url    string
-	Length int64
+	Length int64 `json:",string"`
 	Type   string
 }


### PR DESCRIPTION
As json works with only float64 and when field Length of Enclosure gets big; we will see that nasty error about failing to unmarshal 2.34534e6 to int64.

This way we marshal Length (int64) as string.

Using json.Number brings in too much hassle for not much added value; and JavaScript in NoSQL databases (CouchDB, MongoDB, etc) doesn't care actually.

Until the day that it really gets annoying (and json.Number gets relevant) this will do.